### PR TITLE
update readme for the beats fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# beats-vendored sarama fork
+
+## warning
+
+This is the wrong branch! This branch is unmaintained and should not be used. You are probably looking for the `beats-fork` branch. See there for more detailed instructions.
+
+The `beats-fork` branch of this repository contains the version of Sarama vendored with beats, which (when necessary) includes bug fixes that have not yet reached an official Sarama release.
+
+Original readme follows:
+
 # sarama
 
 [![GoDoc](https://godoc.org/github.com/Shopify/sarama?status.svg)](https://godoc.org/github.com/Shopify/sarama)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the wrong branch! This branch is unmaintained and should not be used. You are probably looking for the `beats-fork` branch. See there for more detailed instructions.
 
-The `beats-fork` branch of this repository contains the version of Sarama vendored with beats, which (when necessary) includes bug fixes that have not yet reached an official Sarama release.
+The `beats-fork` branch of this repository contains the version of Sarama packaged with beats, which (when necessary) includes bug fixes that have not yet reached an official Sarama release.
 
 Original readme follows:
 


### PR DESCRIPTION
Update the main `README.md` for this repository to specifically point out that this is a fork and point to the correct branch (`beats-fork`).

I have also changed the default branch of the repo to point to `beats-fork`, to make it harder to link the wrong one, but editing this file gives an extra safeguard if someone ends up looking at `master` anyway.
