### PR TITLE
Properly report retry counts when refreshing the lead broker

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -535,6 +535,7 @@ func (pp *partitionProducer) dispatch() {
 		}
 	}()
 
+	leaderRetries := 0
 	for msg := range pp.input {
 		if pp.brokerProducer != nil && pp.brokerProducer.abandoned != nil {
 			select {
@@ -579,10 +580,14 @@ func (pp *partitionProducer) dispatch() {
 
 		if pp.brokerProducer == nil {
 			if err := pp.updateLeader(); err != nil {
+				// Report the error on this message and wait for the backoff, then move on to the next one.
 				pp.parent.returnError(msg, err)
-				pp.backoff(msg.retries)
+				pp.backoff(leaderRetries)
+				leaderRetries++
 				continue
 			}
+			// On success, reset the retry count to 0.
+			leaderRetries = 0
 			Logger.Printf("producer/leader/%s/%d selected broker %d\n", pp.topic, pp.partition, pp.leader.ID())
 		}
 


### PR DESCRIPTION
(This is a resubmission of https://github.com/elastic/sarama/pull/7, after we realized we needed to switch to a different base version due to other outstanding bugs. This PR uses the new repository structure documented in https://github.com/elastic/sarama/pull/9 so it applies against the correct branch and base version. Original pull request description below.)

This is a fix for https://github.com/elastic/beats/issues/19015, in which Sarama fails to apply exponential backoff when `Producer.Retry.BackoffFunc` is set to an exponential backoff function.

Sarama tracks producer retries per-message, and updates them when receiving a response from the broker. This means that when there is no broker, the retry count never gets incremented. Thus, retries of send attempts to a valid broker will properly apply the exponential backoff, but retries while connecting to the broker itself will always retry with the initial backoff time.

I have modified the wait so that it tracks retries on the broker itself separately from retries on its pending messages. Local tests as described in https://github.com/elastic/beats/issues/19015 confirm that exponential backoff is now correctly applied when the broker is down.