### PR TITLE
Use gofork for encoding/asn1 to fix ASN errors during Kerberos authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
-	github.com/jcmturner/gofork v1.0.0 // indirect
+	github.com/jcmturner/gofork v1.0.0
 	github.com/klauspost/compress v1.9.8
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/pierrec/lz4 v2.4.1+incompatible

--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -1,13 +1,13 @@
 package sarama
 
 import (
-	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
+	"github.com/jcmturner/gofork/encoding/asn1"
 	"gopkg.in/jcmturner/gokrb5.v7/asn1tools"
 	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
 	"gopkg.in/jcmturner/gokrb5.v7/iana/chksumtype"


### PR DESCRIPTION
This PR applies @kvch's [fix](https://github.com/Shopify/sarama/pull/1697) for a [Kerberos authentication bug](https://github.com/Shopify/sarama/issues/1658), which is checked in to upstream Sarama but has not yet reached a numbered release.