### PR TITLE
Report common unrecoverable connection / authentication errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The current baseline Sarama version is `v1.29.1`.
 
 The additional patches applied to this version are:
 - A fix for exponential backoff when a Kafka broker is down ([issue](https://github.com/Shopify/sarama/issues/1719), [pull request](https://github.com/elastic/sarama/pull/10), [upstream pull request](https://github.com/Shopify/sarama/pull/1720))
+- Report common unrecoverable connection / authentication errors ([issue](https://github.com/elastic/beats/issues/26294), [pull request](https://github.com/elastic/sarama/pull/15))
 
 ## Updating this repository
 

--- a/broker.go
+++ b/broker.go
@@ -282,6 +282,19 @@ func (b *Broker) GetMetadata(request *MetadataRequest) (*MetadataResponse, error
 
 	err := b.sendAndReceive(request, response)
 	if err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			// An EOF while fetching metadata is a special case, since it
+			// usually indicates an unrecoverable protocol mismatch.
+			return nil, ErrFetchMetadataEOF
+		} else if strings.HasPrefix(err.Error(), "tls:") {
+			// Currently there's no good way to extract TLS error types,
+			// as they are represented internally by opaque strings that
+			// are not stable between go versions. However, a TLS error
+			// has very different mitigations than other metadata failures,
+			// so we want to surface it as the real failure.
+			// (see also Broker.sendAndReceiveSASLHandshake)
+			return nil, ErrBadTLSHandshake
+		}
 		return nil, err
 	}
 
@@ -974,6 +987,19 @@ func (b *Broker) sendAndReceiveSASLHandshake(saslType SASLMechanism, version int
 	if err != nil {
 		b.addRequestInFlightMetrics(-1)
 		Logger.Printf("Failed to send SASL handshake %s: %s\n", b.addr, err.Error())
+		if err == io.EOF {
+			return ErrSASLHandshakeSendEOF
+		} else if strings.HasPrefix(err.Error(), "tls:") {
+			// This is a workaround for the fact that the TLS subsystem
+			// generally returns opaque string literals (which are not stable
+			// between go versions) rather than documented / typed errors.
+			// A TLS-related error while sending a SASL handshake almost
+			// always indicates a failure in the underlying TLS handshake,
+			// and we need a way to surface that case to the user, otherwise
+			// it will fall back on "client has run out of available brokers
+			// to talk to", which is hard to troubleshoot.
+			return ErrBadTLSHandshake
+		}
 		return err
 	}
 	b.correlationID++
@@ -983,6 +1009,9 @@ func (b *Broker) sendAndReceiveSASLHandshake(saslType SASLMechanism, version int
 	if err != nil {
 		b.addRequestInFlightMetrics(-1)
 		Logger.Printf("Failed to read SASL handshake header : %s\n", err.Error())
+		if err == io.ErrUnexpectedEOF {
+			return ErrSASLHandshakeReadEOF
+		}
 		return err
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -3,6 +3,7 @@ package sarama
 import (
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -282,7 +283,7 @@ func (b *Broker) GetMetadata(request *MetadataRequest) (*MetadataResponse, error
 
 	err := b.sendAndReceive(request, response)
 	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			// An EOF while fetching metadata is a special case, since it
 			// usually indicates an unrecoverable protocol mismatch.
 			return nil, ErrFetchMetadataEOF
@@ -987,7 +988,7 @@ func (b *Broker) sendAndReceiveSASLHandshake(saslType SASLMechanism, version int
 	if err != nil {
 		b.addRequestInFlightMetrics(-1)
 		Logger.Printf("Failed to send SASL handshake %s: %s\n", b.addr, err.Error())
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return ErrSASLHandshakeSendEOF
 		} else if strings.HasPrefix(err.Error(), "tls:") {
 			// This is a workaround for the fact that the TLS subsystem

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"math/rand"
 	"sort"
 	"sync"
@@ -908,16 +909,16 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 
 		case KError:
 			// if SASL auth error return as this _should_ be a non retryable err for all brokers
-			if err == ErrSASLAuthenticationFailed {
+			if errors.Is(err, ErrSASLAuthenticationFailed) {
 				Logger.Println("client/metadata failed SASL authentication")
 				return err
 			}
 
-			if err == ErrTopicAuthorizationFailed {
+			if errors.Is(err, ErrTopicAuthorizationFailed) {
 				Logger.Println("client is not authorized to access this topic. The topics were: ", topics)
 				return err
 			}
-			if err == ErrUnsupportedSASLMechanism {
+			if errors.Is(err, ErrUnsupportedSASLMechanism) {
 				Logger.Println("requested SASL mechanism is not supported by the broker")
 				return err
 			}
@@ -928,10 +929,10 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 			client.deregisterBroker(broker)
 
 		default:
-			if err == ErrSASLHandshakeReadEOF ||
-				err == ErrSASLHandshakeSendEOF ||
-				err == ErrFetchMetadataEOF ||
-				err == ErrBadTLSHandshake {
+			if errors.Is(err, ErrSASLHandshakeReadEOF) ||
+				errors.Is(err, ErrSASLHandshakeSendEOF) ||
+				errors.Is(err, ErrFetchMetadataEOF) ||
+				errors.Is(err, ErrBadTLSHandshake) {
 				// These errors are typically unrecoverable, so we return them
 				// directly here to avoid falling back on the less useful
 				// "client has run out of brokers" error after retrying.

--- a/errors.go
+++ b/errors.go
@@ -55,6 +55,25 @@ var ErrNoTopicsToUpdateMetadata = errors.New("kafka: no specific topics to updat
 // ErrUnknownScramMechanism is returned when user tries to AlterUserScramCredentials with unknown SCRAM mechanism
 var ErrUnknownScramMechanism = errors.New("kafka: unknown SCRAM mechanism provided")
 
+// ErrSASLHandshakeReadEOF is returned when an unexpected EOF arises reading the SASL handshake header,
+// which usually indicates an invalid server certificate.
+var ErrSASLHandshakeReadEOF = errors.New("kafka: couldn't read SASL handshake (bad broker certificate?)")
+
+// ErrSASLHandshakeSendEOF is returned when an EOF arises initiating a SASL handshake with the broker,
+// which usually indicates that the broker is not expecting a SASL handshake.
+var ErrSASLHandshakeSendEOF = errors.New("kafka: couldn't write SASL handshake (make sure SASL is enabled on the target broker port)")
+
+// ErrFetchMetadataEOF is returned when an unexpected EOF arises while fetching broker metadata.
+// When this is not caused by one of the preceding handshake errors, this often means a plaintext
+// client is attempting to connect to a TLS-enabled broker, or a TLS-only client
+// is attempting to connect to a broker that requires SASL authentication.
+var ErrFetchMetadataEOF = errors.New("kafka: couldn't fetch broker metadata (check that your client and broker are using the same encryption and authentication settings)")
+
+// ErrBadTLSHandshake is returned when there is a TLS error while attempting a SASL handshake or
+// metadata refresh. This usually means that the requested TLS version or cipher is unsupported
+// by the broker.
+var ErrBadTLSHandshake = errors.New("kafka: bad TLS handshake connecting to broker (check that your TLS version and cipher are enabled by the broker)")
+
 // PacketEncodingError is returned from a failure while encoding a Kafka packet. This can happen, for example,
 // if you try to encode a string over 2^15 characters in length, since Kafka's encoding rules do not permit that.
 type PacketEncodingError struct {


### PR DESCRIPTION
Many common connection errors that our users run into -- invalid server certificates, TLS version / cipher mismatches, and similar -- are not reported by the Sarama API, and appear only in Sarama's debug output, with log messages that often don't indicate the specific cause. Because Sarama treats these errors as recoverable, it retries many times, then returns the failure to Beats via the generic error "client has run out of brokers to talk to".

This PR adds four new internal error types to Sarama -- `ErrSASLHandshakeReadEOF`, `ErrSASLHandshakeSendEOF`, `ErrFetchMetadataEOF`, `ErrBadTLSHandshake` -- with descriptive error strings indicating how to troubleshoot the failure. It also treats these (as well as the preexisting `ErrUnsupportedSASLMechanism`) as unrecoverable errors, so they are reported directly back to Beats, where they are logged as an error. This should give much more useful / consistent log messages when there is an error connecting to a Kafka server.

## Testing details

These cases were analyzed and tested with a variant of the Beats Kafka container (in the beats repository under `testing/environments/docker`). In addition to the container's current plaintext port 9092 and SASL/SCRAM port 9093, it added a TLS port 9094 for checking TLS-only scenarios. Most tests were run with the Kafka output, with this baseline configuration:

```yml
output.kafka:
  hosts: ["127.0.0.1:9093"]

  topic: "filebeat-kafka-output-sasl-ssl"
  protocol: "https"
  sasl.mechanism: "SCRAM-SHA-512"

  ssl.certificate_authorities: ["/Users/fae/go/src/github.com/elastic/beats/testing/environments/docker/kafka/certs/ca-cert"]
  username: "beats"
  password: "KafkaTest"
```

Failures were then tested by varying the configurations, as follows:

- Bad password: change password to `"idk"`
- Bad server certificate: remove `ssl.certificate_authorities`
- Unsupported cipher: add `ssl.cipher_suites: [ECDHE-ECDSA-AES-128-CBC-SHA]`
- SASL client / plaintext broker: change `hosts` to `["127.0.0.1:9092"]`
- Unsupported TLS version: add `ssl.supported_protocols: [TLSv1.3]`
- Unsupported SASL mechanism: change `sasl.mechanism` to `"SCRAM-SHA-256"`
- TLS-only client, SASL broker: remove username/password and `sasl.mechanism`
- TLS-only client, unsupported TLS version: remove username/password and `sasl.mechanism`, add `ssl.supported_protocols: [TLSv1.3]`
- plaintext client, SASL broker: remove username/password and `sasl.mechanism`, change `protocol` to `"http"`

All these failure modes now give descriptive error logs when run against this PR.

Closes: https://github.com/elastic/beats/issues/26294