### PR TITLE
Replace IBM imports by elastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ Updates should always target an explicit release tag. To perform the update, fir
     git checkout upstream/beats-fork
     git checkout -b version-upgrade
 
+    # Restore the IBM imports
+    find . -path ./examples -prune -o -name "*.go" -print0 \
+    | xargs -0 sed -i 's/"github\.com\/elastic\/sarama/"github\.com\/IBM\/sarama/g'
+
     # Merge the target version into your new branch (replace
     # the version tag as appropriate).
     # If the new version conflicts with the outstanding bug
     # fixes, you will need to resolve those conflicts in this
     # step.
     git merge v1.26.4
+
+    # Restore the elastic imports
+    find . -path ./examples -prune -o -name "*.go" -print0 \
+    | xargs -0 sed -i 's/"github\.com\/IBM\/sarama/"github\.com\/elastic\/sarama/g'
 
     # Push the update back to your fork on github.
     git push --set-upstream origin version-upgrade

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/require"
 
-	"github.com/IBM/sarama/internal/toxiproxy"
+	"github.com/elastic/sarama/internal/toxiproxy"
 )
 
 const TestBatchSize = 1000

--- a/functional_test.go
+++ b/functional_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/IBM/sarama/internal/toxiproxy"
+	"github.com/elastic/sarama/internal/toxiproxy"
 )
 
 const uncommittedTopic = "uncommitted-topic-test-4"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/elastic/sarama
 go 1.19
 
 require (
-	github.com/IBM/sarama v1.43.3
 	github.com/davecgh/go-spew v1.1.1
 	github.com/eapache/go-resiliency v1.7.0
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3
@@ -27,10 +26,10 @@ require (
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/IBM/sarama v1.43.3 h1:Yj6L2IaNvb2mRBop39N7mmJAHBVY3dTPncr3qGVkxPA=
-github.com/IBM/sarama v1.43.3/go.mod h1:FVIRaLrhK3Cla/9FfRF5X9Zua2KpS3SYIXxhac1H+FQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -38,7 +36,9 @@ github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJk
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -99,6 +99,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 // AsyncProducer implements sarama's Producer interface for testing purposes.

--- a/mocks/async_producer_test.go
+++ b/mocks/async_producer_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 func generateRegexpChecker(re string) func([]byte) error {

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 // Consumer implements sarama's Consumer interface for testing purposes.

--- a/mocks/consumer_test.go
+++ b/mocks/consumer_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 func TestMockConsumerImplementsConsumerInterface(t *testing.T) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 // ErrorReporter is a simple interface that includes the testing.T methods we use to report

--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 // SyncProducer implements sarama's SyncProducer interface for testing purposes.

--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 func TestMockSyncProducerImplementsSyncProducerInterface(t *testing.T) {

--- a/tools/kafka-console-consumer/kafka-console-consumer.go
+++ b/tools/kafka-console-consumer/kafka-console-consumer.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/IBM/sarama"
-	"github.com/IBM/sarama/tools/tls"
+	"github.com/elastic/sarama"
+	"github.com/elastic/sarama/tools/tls"
 )
 
 var (

--- a/tools/kafka-console-partitionconsumer/kafka-console-partitionconsumer.go
+++ b/tools/kafka-console-partitionconsumer/kafka-console-partitionconsumer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/IBM/sarama"
+	"github.com/elastic/sarama"
 )
 
 var (

--- a/tools/kafka-console-producer/kafka-console-producer.go
+++ b/tools/kafka-console-producer/kafka-console-producer.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 
-	"github.com/IBM/sarama"
-	"github.com/IBM/sarama/tools/tls"
+	"github.com/elastic/sarama"
+	"github.com/elastic/sarama/tools/tls"
 )
 
 var (

--- a/tools/kafka-producer-performance/main.go
+++ b/tools/kafka-producer-performance/main.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 
-	"github.com/IBM/sarama"
-	"github.com/IBM/sarama/tools/tls"
+	"github.com/elastic/sarama"
+	"github.com/elastic/sarama/tools/tls"
 )
 
 var (


### PR DESCRIPTION
It replaces all instances of import `github.com/IBM/sarama*` by the elastic version, `github.com/elastic/sarama`.
Some packages, specially the `mocks/` was using the IBM version, making it impossible to use with code importing the elastic version of this library.