### PR TITLE
Clean up broker connections when returning a short-circuit error during metadata fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The current baseline Sarama version is `v1.43.3`.
 The additional patches applied to this version are:
 - A fix for exponential backoff when a Kafka broker is down ([issue](https://github.com/Shopify/sarama/issues/1719), [pull request](https://github.com/elastic/sarama/pull/10), [upstream pull request](https://github.com/Shopify/sarama/pull/1720))
 - Report common unrecoverable connection / authentication errors ([issue](https://github.com/elastic/beats/issues/26294), [pull request](https://github.com/elastic/sarama/pull/15))
+  * A fix to the verbose error reporting where a TCP reset signal could prevent a broker connection from being cleaned up properly ([issue](https://github.com/elastic/beats/issues/44606), [pull request]())
 - Disable kerberos if requirefips tags is passed ([issue](https://github.com/elastic/beats/issues/42867), [pull request](https://github.com/elastic/sarama/pull/25))
 
 ## Updating this repository

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The current baseline Sarama version is `v1.43.3`.
 The additional patches applied to this version are:
 - A fix for exponential backoff when a Kafka broker is down ([issue](https://github.com/Shopify/sarama/issues/1719), [pull request](https://github.com/elastic/sarama/pull/10), [upstream pull request](https://github.com/Shopify/sarama/pull/1720))
 - Report common unrecoverable connection / authentication errors ([issue](https://github.com/elastic/beats/issues/26294), [pull request](https://github.com/elastic/sarama/pull/15))
-  * A fix to the verbose error reporting where a TCP reset signal could prevent a broker connection from being cleaned up properly ([issue](https://github.com/elastic/beats/issues/44606), [pull request]())
+  * A fix to the verbose error reporting where a TCP reset signal could prevent a broker connection from being cleaned up properly ([issue](https://github.com/elastic/beats/issues/44606), [pull request](https://github.com/elastic/sarama/pull/28))
 - Disable kerberos if requirefips tags is passed ([issue](https://github.com/elastic/beats/issues/42867), [pull request](https://github.com/elastic/sarama/pull/25))
 
 ## Updating this repository

--- a/client.go
+++ b/client.go
@@ -1074,26 +1074,26 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 			_ = broker.Close()
 			client.deregisterBroker(broker)
 		} else {
-			if errors.Is(err, ErrSASLHandshakeReadEOF) ||
-				errors.Is(err, ErrSASLHandshakeSendEOF) ||
-				errors.Is(err, ErrFetchMetadataEOF) ||
-				errors.Is(err, ErrBadTLSHandshake) {
-				// These errors are typically unrecoverable, so we return them
-				// directly here to avoid falling back on the less useful
-				// "client has run out of brokers" error after retrying.
-				//
-				// Beats-specific note: if these errors arise, the connection
-				// will still be retried, so this will not break things if the
-				// error is temporary; it will just retry at the user-configured
-				// rate, and with more informative log messages.
-				return err
-			}
-
 			// some other error, remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)
 			brokerErrors = append(brokerErrors, err)
 			_ = broker.Close()
 			client.deregisterBroker(broker)
+
+			if errors.Is(err, ErrSASLHandshakeReadEOF) ||
+				errors.Is(err, ErrSASLHandshakeSendEOF) ||
+				errors.Is(err, ErrFetchMetadataEOF) ||
+				errors.Is(err, ErrBadTLSHandshake) {
+				// These errors are typically (but not always) unrecoverable, so we
+				// return them directly here to avoid falling back on the less useful
+				// "client has run out of brokers" error after retrying.
+				//
+				// Beats-specific note: if these errors arise, the connection
+				// will still be retried, so this will not break things if the
+				// error is temporary; it will just retry the next broker at the
+				// user-configured rate, and with more informative log messages.
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Reorders the short-circuit error checking to do broker cleanup first. Fixes https://github.com/elastic/beats/issues/44606.