### PR TITLE
fix FIPS build for beats: move SASL v2 Kerberos auth behind build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The additional patches applied to this version are:
   * A fix to the verbose error reporting where a TCP reset signal could prevent a broker connection from being cleaned up properly ([issue](https://github.com/elastic/beats/issues/44606), [pull request](https://github.com/elastic/sarama/pull/28))
 - Disable kerberos if requirefips tags is passed ([issue](https://github.com/elastic/beats/issues/42867), [pull request](https://github.com/elastic/sarama/pull/25))
 - Replaced `jcmturner/gokrb5` library with elastic fork i.e `elastic/gokrb5` [pull request](https://github.com/elastic/sarama/pull/29)
+- move SASL v2 Kerberos auth behind FIPS build tags [pull request](https://github.com/elastic/sarama/pull/32) [issue](https://github.com/elastic/sarama/issues/30)
 
 ## Updating this repository
 

--- a/broker.go
+++ b/broker.go
@@ -1385,11 +1385,7 @@ func (b *Broker) authenticateViaSASLv1() error {
 
 	switch b.conf.Net.SASL.Mechanism {
 	case SASLTypeGSSAPI:
-		b.kerberosAuthenticator.Config = &b.conf.Net.SASL.GSSAPI
-		if b.kerberosAuthenticator.NewKerberosClientFunc == nil {
-			b.kerberosAuthenticator.NewKerberosClientFunc = NewKerberosClient
-		}
-		return b.kerberosAuthenticator.AuthorizeV2(b, authSendReceiver)
+		return b.sendAndReceiveKerberosV2(authSendReceiver)
 	case SASLTypeOAuth:
 		provider := b.conf.Net.SASL.TokenProvider
 		return b.sendAndReceiveSASLOAuth(authSendReceiver, provider)

--- a/broker_fips.go
+++ b/broker_fips.go
@@ -9,3 +9,9 @@ type GSSAPIKerberosAuth struct{}
 func (b *Broker) sendAndReceiveKerberos() error {
 	return errors.New("kerberos not allowed in fips mode")
 }
+
+func (b *Broker) sendAndReceiveKerberosV2(
+	authSendReceiver func(authBytes []byte) (*SaslAuthenticateResponse, error),
+) error {
+	return errors.New("kerberos not allowed in fips mode")
+}

--- a/broker_nofips.go
+++ b/broker_nofips.go
@@ -9,3 +9,13 @@ func (b *Broker) sendAndReceiveKerberos() error {
 	}
 	return b.kerberosAuthenticator.Authorize(b)
 }
+
+func (b *Broker) sendAndReceiveKerberosV2(
+	authSendReceiver func(authBytes []byte) (*SaslAuthenticateResponse, error),
+) error {
+	b.kerberosAuthenticator.Config = &b.conf.Net.SASL.GSSAPI
+	if b.kerberosAuthenticator.NewKerberosClientFunc == nil {
+		b.kerberosAuthenticator.NewKerberosClientFunc = NewKerberosClient
+	}
+	return b.kerberosAuthenticator.AuthorizeV2(b, authSendReceiver)
+}


### PR DESCRIPTION
### Proposed commit message

    move SASL v2 Kerberos auth behind FIPS build tags
    
    The upstream v1.46.3 merge introduced SASL v2 GSSAPI/Kerberos authentication
    code directly in broker.go, which accesses GSSAPIKerberosAuth fields
    and methods excluded from FIPS builds. Apply the same dispatch pattern
    used for the v0 path: broker.go calls sendAndReceiveKerberosV2(),
    broker_nofips.go has the real implementation, broker_fips.go returns
    an error.
    
    Assisted by Cursor


- Closes #30 